### PR TITLE
Updated the AntiGrief to also AntiSpoof Players.

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -607,17 +607,26 @@ namespace FsOptimizer
 
                 try
                 {
+                    var id = NetworkInfo.LastReceivedUser.Value;
                     if (NetworkInfo.IsHost)
                     {
                         var data = received.ReadData<ConnectionRequestData>();
-                        MelonLogger.Msg($"[AntiGrief] Incoming connection: PlatformID={data.PlatformID}, Version={data.Version}");
+                        MelonLogger.Msg($"[AntiGrief] Incoming connection: PlatformID={id}, Version={data.Version}");
+                        if (data.PlatformID != id)
+                        {
+
+                            MelonLogger.Warning($"[AntiGrief] Spoofed ID detected! Blocking connection: {id} ");
+                            ShowNotification($"[AntiGrief] Spoofed ID detected! Blocking connection: {id}", NotificationType.Warning);
+                            ConnectionSender.SendConnectionDeny(id, "[AntiGrief]");
+                            return false;
+                        }
                     }
                     if (NetworkInfo.Layer.RequiresValidId)
                     {
                         var data = received.ReadData<ConnectionRequestData>();
                         if (NetworkInfo.IsSpoofed(data.PlatformID))
                         {
-                            var id = NetworkInfo.LastReceivedUser.Value;
+                            
                             MelonLogger.Warning($"[AntiGrief] Spoofed ID detected! Blocking connection: {id}");
                             ShowNotification($"[AntiGrief] Spoofed ID detected! Blocking connection: {id}", NotificationType.Warning);
                             ConnectionSender.SendConnectionDeny(id, "[AntiGrief]");

--- a/Main.cs
+++ b/Main.cs
@@ -607,26 +607,17 @@ namespace FsOptimizer
 
                 try
                 {
-                    var id = NetworkInfo.LastReceivedUser.Value;
                     if (NetworkInfo.IsHost)
                     {
                         var data = received.ReadData<ConnectionRequestData>();
-                        MelonLogger.Msg($"[AntiGrief] Incoming connection: PlatformID={id}, Version={data.Version}");
-                        if (data.PlatformID != id)
-                        {
-
-                            MelonLogger.Warning($"[AntiGrief] Spoofed ID detected! Blocking connection: {id} ");
-                            ShowNotification($"[AntiGrief] Spoofed ID detected! Blocking connection: {id}", NotificationType.Warning);
-                            ConnectionSender.SendConnectionDeny(id, "[AntiGrief]");
-                            return false;
-                        }
+                        MelonLogger.Msg($"[AntiGrief] Incoming connection: PlatformID={data.PlatformID}, Version={data.Version}");
                     }
                     if (NetworkInfo.Layer.RequiresValidId)
                     {
                         var data = received.ReadData<ConnectionRequestData>();
                         if (NetworkInfo.IsSpoofed(data.PlatformID))
                         {
-                            
+                            var id = NetworkInfo.LastReceivedUser.Value;
                             MelonLogger.Warning($"[AntiGrief] Spoofed ID detected! Blocking connection: {id}");
                             ShowNotification($"[AntiGrief] Spoofed ID detected! Blocking connection: {id}", NotificationType.Warning);
                             ConnectionSender.SendConnectionDeny(id, "[AntiGrief]");


### PR DESCRIPTION
Ignore the first 3 commits i was having issues with renaming a commit.
This will stop client user from joining with a spoofed ID, as they are able to spoof PlatformID now, the id variable is the only thing which can accurately get the longID of the user.
Created an IF statement to block joining if these do not match, and updated the ID variable for joining users, to use the unspoofable variable.